### PR TITLE
fix: MCD-1076 Bump Node runtime to 24.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ branding:
   color: yellow
   icon: alert-triangle
 runs:
-  using: "node16"
+  using: "node24"
   main: "index.js"


### PR DESCRIPTION
## Summary

GitHub force-bumps Node 20 actions to Node 24 on 2026-06-02, then removes Node 20 from runners on 2026-09-16. Declare `node24` explicitly so this action keeps working when Node 20 is removed.

The action's source has no Node-version-sensitive code; the bundled `node_modules/` (CommonJS, `@actions/core`, `@actions/github`, `@octokit/rest`) runs unchanged on Node 24. Only `action.yml` changes.

## Release plan

Tag this as **`3.0.0`** once merged (the Node runtime is the kind of consumer-visible breaking change `actions/checkout` uses a major bump for).

## Consumers we know about (separate PRs to follow)

- `drunomics/lupus-nuxt3-kickstart` → fixed in the PR opened from MCD-1076.
- `drunomics/ldp-project` (root + `frontend/`) → @2.0.0, needs bump.
- `drunomics/ld-cloud-project` → @1.0.0, needs bump too.

Refs: MCD-1076

---
_Drafted with Claude Code from claude-vm-1._